### PR TITLE
placing gen. PDF into folder which is getting served

### DIFF
--- a/src/markdown-combine.js
+++ b/src/markdown-combine.js
@@ -9,7 +9,7 @@ const [readFile, writeFile, exists] = [fs.readFile, fs.writeFile, fs.exists].map
   util.promisify(fn),
 );
 
-const combineMarkdowns = ({ contents, pathToStatic, mainMdFilename }) => async links => {
+const combineMarkdowns = ({ contents, pathToStatic, mainMdFilename, pathToDocsifyEntryPoint }) => async links => {
   try {
     const files = await Promise.all(
       await links.map(async filename => {
@@ -30,7 +30,7 @@ const combineMarkdowns = ({ contents, pathToStatic, mainMdFilename }) => async l
       }),
     );
 
-    const resultFilePath = path.resolve(pathToStatic, mainMdFilename);
+    const resultFilePath = path.resolve(pathToDocsifyEntryPoint, pathToStatic, mainMdFilename);
 
     try {
       const content = files


### PR DESCRIPTION
placing generated PDF into the folder which is getting served, so it is accessable from the webserver when creating the PDFs

Used config:

```
  "docsifytopdf": {
    "contents": [
      "docs/_sidebar.md"
    ],
    "pathToPublic": "pdf/readme.pdf",
    "removeTemp": false,
    "emulateMedia": "screen",
    "pathToDocsifyEntryPoint": "./docs",
    "mainMdFilename": "readme.md"
  }
```