### PR TITLE
Add --no-sandbox argument when launching puppeteer

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,7 @@ const renderPdf = async ({
       width: 1200,
       height: 1000,
     },
+    args: ["--no-sandbox"]
   });
   try {
     const mainMdFilenameWithoutExt = path.parse(mainMdFilename).name;


### PR DESCRIPTION
I'm trying to run the PDF conversion in AWS Amplify which runs as root on Linux. My build was failing with the following error:

```
puppeteer renderer error:
[WARNING]: Error: Failed to launch chrome!
[0728/213339.187531:ERROR:zygote_host_impl_linux.cc(89)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180. TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
```

Adding `--no-sandbox`  to the `args` used when launching puppeteer fixed this for me

See this page for more detail:
https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox